### PR TITLE
Revert "fix: don't change PHP functions which are reserved words  (#3…

### DIFF
--- a/showcase/php/tests/ShowcaseIntegrationTest.php
+++ b/showcase/php/tests/ShowcaseIntegrationTest.php
@@ -48,7 +48,7 @@ class ShowcaseIntegrationTest extends TestCase
      */
     public function testUnary($client)
     {
-        $response = $client->echo([
+        $response = $client->echo_([
             'content' => '"Wales snail hail fails!" wails Gail'
         ]);
         $this->assertEquals(
@@ -65,7 +65,7 @@ class ShowcaseIntegrationTest extends TestCase
     public function testFailUnary($client)
     {
         try {
-            $client->echo([
+            $client->echo_([
                 'error' => (new Status())
                     ->setCode(Code::INVALID_ARGUMENT)
                     ->setMessage("Unary error message"),

--- a/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
+++ b/src/main/java/com/google/api/codegen/util/php/PhpNameFormatter.java
@@ -63,17 +63,17 @@ public class PhpNameFormatter implements NameFormatter {
 
   @Override
   public String publicMethodName(Name name) {
-    return name.toLowerCamel();
+    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
   }
 
   @Override
   public String privateMethodName(Name name) {
-    return name.toLowerCamel();
+    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
   }
 
   @Override
   public String staticFunctionName(Name name) {
-    return name.toLowerCamel();
+    return wrapIfKeywordOrBuiltIn(name.toLowerCamel());
   }
 
   @Override


### PR DESCRIPTION
…317)"

This reverts commit 3ff8ca91ff8023549dc8d95cee29277520ef87ce.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
